### PR TITLE
Tomcat container's version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.0
+FROM tomcat:8.0-jre8
 
 RUN rm -rf $CATALINA_HOME/webapps/*
 COPY ./target/*.war $CATALINA_HOME/webapps/ROOT.war

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
         <encoder>
-            <Pattern>.%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %n
-            </Pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>TRACE</level>
-        </filter>
     </appender>
 
-    <root>
-        <level value="DEBUG" />
-        <appender-ref ref="consoleAppender" />
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
 is not the same as the one used to compile project : see : http://stackoverflow.com/questions/35824617/tomcat-8-no-spring-webapplicationinitializer-types-detected-on-classpath
