### PR TITLE
Fix config + change name of the mongo.name property

### DIFF
--- a/src/main/java/org/cheztone/backend/SpringConfigInitializer.java
+++ b/src/main/java/org/cheztone/backend/SpringConfigInitializer.java
@@ -1,5 +1,6 @@
 package org.cheztone.backend;
 
+import org.cheztone.backend.config.DataSourceConfig;
 import org.cheztone.backend.config.WebMvcConfig;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
@@ -7,7 +8,7 @@ public class SpringConfigInitializer extends AbstractAnnotationConfigDispatcherS
 
 	@Override
 	protected Class<?>[] getRootConfigClasses() {
-		return  new Class[] { WebMvcConfig.class  };
+		return  new Class[] { WebMvcConfig.class, DataSourceConfig.class};
 	}
 
 	@Override

--- a/src/main/java/org/cheztone/backend/config/DataSourceConfig.java
+++ b/src/main/java/org/cheztone/backend/config/DataSourceConfig.java
@@ -7,11 +7,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
+@EnableMongoRepositories(basePackages = "org.cheztone.backend.repository")
 @PropertySource({ "classpath:mongodb-data-source.properties" })
 public class DataSourceConfig extends AbstractMongoConfiguration {
 
@@ -20,14 +22,13 @@ public class DataSourceConfig extends AbstractMongoConfiguration {
 
     @Override
     public String getDatabaseName(){
-        return env.getRequiredProperty("mongo.name");
+        return env.getProperty("mongo.database.name");
     }
 
     @Override
     @Bean
     public Mongo mongo() throws Exception {
-
-        ServerAddress serverAddress = new ServerAddress(env.getRequiredProperty("mongo.host"));
+        ServerAddress serverAddress = new ServerAddress(env.getProperty("mongo.host"));
         List<MongoCredential> credentials = new ArrayList<>();
         /*credentials.add(MongoCredential.createScramSha1Credential(
                 env.getRequiredProperty("mongo.username"),

--- a/src/main/java/org/cheztone/backend/config/WebMvcConfig.java
+++ b/src/main/java/org/cheztone/backend/config/WebMvcConfig.java
@@ -8,7 +8,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @Configuration
 @EnableWebMvc
-@EnableMongoRepositories(basePackages = "org.cheztone.backend.repository")
 @ComponentScan(basePackages = {"org.cheztone.backend"})
 public class WebMvcConfig extends WebMvcConfigurerAdapter {
 

--- a/src/main/resources/mongodb-data-source.properties
+++ b/src/main/resources/mongodb-data-source.properties
@@ -1,2 +1,2 @@
-mongo.name=backend
+mongo.database.name=backend
 mongo.host=mongo:27017


### PR DESCRIPTION
 As we use mongo_name for docker linking, the property have to be rename as mongo.database.name in order to avoid conflict.
